### PR TITLE
ICM-31247: add option to disable fill cache on reads

### DIFF
--- a/src/options.cc
+++ b/src/options.cc
@@ -319,12 +319,19 @@ lrocksdb_readoptions_t *lrocksdb_get_readoptions(lua_State *L, int index) {
 void lrocksdb_readoptions_set_from_table(lua_State *L, int index, rocksdb_readoptions_t *opt) {
   lua_pushvalue(L, index);
   lua_pushnil(L);
-  while (lua_next(L, -2))
-  {
+
+  while (lua_next(L, -2)) {
     lua_pushvalue(L, -2);
-   //TODO: const char *key = lua_tostring(L, -1);
+    const char *key = lua_tostring(L, -1);
+
+    if (strcmp(key, "fill_cache") == 0) {
+      unsigned char fill_cache = lua_toboolean(L, -2);
+      rocksdb_readoptions_set_fill_cache(opt, fill_cache);
+    }
+
     lua_pop(L, 2);
   }
+
   lua_pop(L, 1);
 }
 

--- a/test/rocksdb.lua
+++ b/test/rocksdb.lua
@@ -72,6 +72,7 @@ assert(ok == false)
 read_only_db:close()
 
 -- open for read only once
+local once_readoptions = rocksdb.readoptions({fill_cache = true})
 local error_if_wal_files_exists = false
 local read_only_db_once = rocksdb.open_for_read_only_once(options, "/tmp/rocksdb.test", error_if_wal_files_exists)
 assert(read_only_db_once)
@@ -79,7 +80,7 @@ print("start.read_only_db_once: get")
 for i = 0, 1000 do
   key = format("lrocks_db_key:%d", i)
   expected_value = format("lrocks_db_value:%d", i)
-  value = read_only_db_once:get(readoptions, key)
+  value = read_only_db_once:get(once_readoptions, key)
   assert(value == expected_value)
 end
 print("done.read_only_db_once: get")


### PR DESCRIPTION
Add option to disable fill cache on reads, so read only instance of RocksDB in a multiprocess environment won't get stale data
